### PR TITLE
Disable alerts for recently updated voters

### DIFF
--- a/.pylint.ini
+++ b/.pylint.ini
@@ -67,6 +67,7 @@ disable=
     too-many-branches,
     too-many-instance-attributes,
     unsupported-assignment-operation,
+    too-many-return-statements,
 
 # Enable the message,report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/ballotbuddies/alerts/models.py
+++ b/ballotbuddies/alerts/models.py
@@ -51,6 +51,12 @@ class Profile(models.Model):
             return False
         if self.always_alert:
             return True
+        if not self.voter.updated:
+            # TODO: Remove this case when unsubscribe link is added
+            # https://github.com/citizenlabsgr/ballotbuddies/issues/192
+            return False
+        if self.voter.updated > timezone.now() - timedelta(days=7):
+            return False
         if self.voter.complete:
             if self.voter.progress.actions:
                 if 0 < self.voter.progress.election.days < 7:

--- a/ballotbuddies/alerts/tests/test_models.py
+++ b/ballotbuddies/alerts/tests/test_models.py
@@ -3,6 +3,8 @@
 
 from datetime import timedelta
 
+from django.utils import timezone
+
 import pytest
 
 from ballotbuddies.alerts.models import Message, Profile
@@ -52,6 +54,16 @@ def describe_profile():
             profile = Profile(voter=Voter(user=User()))
 
             expect(profile.should_alert) == False
+
+        def is_false_with_recently_updated_voter(expect, profile: Profile):
+            assert profile.voter.complete
+            profile.staleness = timedelta(days=99)
+
+            profile.voter.updated = timezone.now() - timedelta(days=6)
+            expect(profile.should_alert) == False
+
+            profile.voter.updated = timezone.now() - timedelta(days=8)
+            expect(profile.should_alert) == True
 
 
 def describe_message():

--- a/ballotbuddies/alerts/tests/test_models.py
+++ b/ballotbuddies/alerts/tests/test_models.py
@@ -71,7 +71,7 @@ def describe_message():
         def it_includes_days_to_election(expect, voter):
             message = Message(profile=Profile(voter=voter))
 
-            expect(str(message)) == "Your Friends are Preparing to Vote in 32 Days"
+            expect(str(message)) == "Your Friends are Preparing to Vote in 48 Days"
 
     def describe_add():
         def it_replaces_legal_name(expect):

--- a/ballotbuddies/buddies/constants.py
+++ b/ballotbuddies/buddies/constants.py
@@ -12,7 +12,7 @@ PREVIEW_URL = PREVIEW_HOST + "/elections/{election}/precincts/{precinct}"
 REGISTRATION_DEADLINE_DELTA = timedelta(days=15)  # common guidance
 ABSENTEE_REQUESTED_DEADLINE_DELTA = timedelta(weeks=4)  # buffer for mail service
 ABSENTEE_RECEIVED_DEADLINE_DELTA = timedelta(weeks=2)  # buffer for mail service
-BALLOT_AVAILABLE_DEADLINE_DAYS = 30  # SOS is supposed to finalize ballots a month out
+BALLOT_AVAILABLE_DEADLINE_DAYS = 45  # SOS is supposed to finalize ballots a month out
 BALLOT_AVAILABLE_DEADLINE_DELTA = timedelta(days=BALLOT_AVAILABLE_DEADLINE_DAYS)
 BALLOT_COMPLETED_DEADLINE_DELTA = timedelta(days=1)  # common guidance
 BALLOT_SENT_DEADLINE_DELTA = timedelta(weeks=3)  # buffer for mail service
@@ -63,7 +63,7 @@ UNREGISTERED = VoterData(
             "color": "default",
             "url": "",
             "date": "",
-            "deadline": "2021-10-03",
+            "deadline": "2021-09-18",
         },
         "ballot_completed": {
             "color": "default",
@@ -147,7 +147,7 @@ REGISTERED = VoterData(
             "color": "default",
             "url": "",
             "date": "",
-            "deadline": "2021-10-03",
+            "deadline": "2021-09-18",
         },
         "ballot_completed": {
             "color": "default",
@@ -251,7 +251,7 @@ VOTED = VoterData(
             "color": "success",
             "url": "https://share.michiganelections.io/elections/45/precincts/5943",
             "date": "",
-            "deadline": "2021-10-03",
+            "deadline": "2021-09-18",
         },
         "ballot_completed": {
             "color": "success text-muted",

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -13,7 +13,7 @@ BASE_URL = "http://example.com"
 
 ALLOW_DEBUG = True
 
-TODAY = date(2021, 10, 1)
+TODAY = date(2021, 9, 15)
 
 ###############################################################################
 # Core

--- a/templates/profile/_table.html
+++ b/templates/profile/_table.html
@@ -266,7 +266,7 @@
                     </td>
                 {% endif %}
             {% else %}
-            <td colspan="2" class="text-center table-{{ voter.progress.voted.color }} border-start">
+            <td colspan="2" class="text-center table-{{ voter.progress.voted.color }} border-start"></td>
             {% endif %}
 
             <td class="text-center border-start {% if voter.progress.voted %} text-muted {% endif %}">


### PR DESCRIPTION
This will prevent overly eager emails when sample ballots are still being gathered.

Relates to #192.