### PR TITLE
Ask lastpass to ignore the first name field on the profile

### DIFF
--- a/ballotbuddies/buddies/forms.py
+++ b/ballotbuddies/buddies/forms.py
@@ -46,6 +46,7 @@ class VoterForm(forms.ModelForm):
         self.fields["birth_date"].widget.attrs["placeholder"] = "mm/dd/yyyy"
         self.fields["birth_date"].widget.attrs["data-date-format"] = "mm/dd/yyyy"
         self.fields["zip_code"].required = True
+        self.fields["first_name"].widget.attrs["data-lpignore"] = True
         if locked:
             del self.fields["email"]
             if not kwargs["initial"].get("nickname"):


### PR DESCRIPTION
Closes #223.  Hopefully.

I don't have LastPass so I can't test this myself, but according to their documentation it's the inclusion of this data attribute that attempts to disable autofill ([ref](https://support.lastpass.com/s/document-item?language=en_US&bundleId=lastpass&topicId=LastPass/c_lp_prevent_fields_from_being_filled_automatically.html&_LANG=enus)).  Note that this also requires folks' own lastpass to be configured to respect the field.

Some folks on StackOverflow also indicate that the whole _form_ needs autocomplete to be turned off ([ref](https://stackoverflow.com/a/28216951)), but I'm not sure if that's desired for this profile form -- nor is it called out in the above documentation -- so I figured I might start here.

Also the last time I wrote anything in Python was like ten years ago and I've never worked in a django app, so happy to hear about better ways to go about accomplishing this task.

<img width="1677" alt="Screenshot 2024-03-29 at 5 55 33 PM" src="https://github.com/citizenlabsgr/ballotbuddies/assets/59452077/f1e5db2b-19b2-4b4a-956f-600f0f308c53">
